### PR TITLE
fix args expansion - add more features

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+   branches: [master]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'  # latest LTS
+          - '1'
+          - 'nightly'
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:  # spare windows/macos CI credits
+          - os: windows-latest
+            version: '1'
+            arch: x64
+          - os: macOS-latest
+            version: '1'
+            arch: x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@latest
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info

--- a/src/TimerOutputsTracked.jl
+++ b/src/TimerOutputsTracked.jl
@@ -7,8 +7,8 @@ using MacroTools
 const TRACKED_FUNCS = Set{Function}()
 const TO = TimerOutput()
 
-verbose() = false
-show_argtypes() = false
+const VERBOSE = Ref(false)
+const SHOW_ARGTYPES = Ref(false)
 
 Cassette.@context TOCtx
 
@@ -16,9 +16,9 @@ Cassette.@context TOCtx
 function Cassette.overdub(ctx::TOCtx, f, args...)
     if f in TRACKED_FUNCS
         argtypes = typeof.(args)
-        verbose() && println("OVERDUBBING: ", f, argtypes)
+        VERBOSE[] && println("OVERDUBBING: ", f, argtypes)
         # return @timeit gettimer() "$f" f(args...)
-        timer_groupname = if show_argtypes()
+        timer_groupname = if SHOW_ARGTYPES[]
             "$f $argtypes"
         else
             "$f"

--- a/src/TimerOutputsTracked.jl
+++ b/src/TimerOutputsTracked.jl
@@ -13,6 +13,7 @@ Cassette.@context TOCtx
 function Cassette.overdub(ctx::TOCtx, f, args...)
     kw = ctx.metadata[:kw]  # github.com/JuliaLabs/Cassette.jl/issues/152
     isempty(kw) || @warn "discarding keyword arguments" kw  # TODO: handle keyword arguments ?
+    @show f, f in TRACKED_FUNCS
     if f in TRACKED_FUNCS
         argtypes = typeof.(args)
         ctx.metadata[:verbose] && println("OVERDUBBING: ", f, argtypes)
@@ -66,9 +67,9 @@ macro timetracked(ex, kw...)
 end
 
 """
-    track(m::Module)
+    track(m::Module; all = false)
 
-Track functions exported from a module.
+Track functions exported from a module, and optionally the un-exported ones.
 """
 track(m::Module; all = false) =
     TimerOutputsTracked.track(filter(x -> x isa Function, getfield.(Ref(m), names(m; all)))...)

--- a/src/TimerOutputsTracked.jl
+++ b/src/TimerOutputsTracked.jl
@@ -18,10 +18,10 @@ function Cassette.overdub(ctx::TOCtx, f, args...)
         argtypes = typeof.(args)
         verbose() && println("OVERDUBBING: ", f, argtypes)
         # return @timeit gettimer() "$f" f(args...)
-        if show_argtypes()
-            timer_groupname = "$f $argtypes"
+        timer_groupname = if show_argtypes()
+            "$f $argtypes"
         else
-            timer_groupname = "$f"
+            "$f"
         end
         return @timeit gettimer() timer_groupname Cassette.recurse(ctx, f, args...)
     else
@@ -42,9 +42,9 @@ end
 
 macro timetracked(ex)
     @capture(ex, f_(args__))
-    esc(quote
-        TimerOutputsTracked.timetracked($f, $(args)...)
-    end)
+    quote
+        TimerOutputsTracked.timetracked($f, $(args...))
+    end |> esc
 end
 
 function track(f)

--- a/src/TimerOutputsTracked.jl
+++ b/src/TimerOutputsTracked.jl
@@ -9,6 +9,8 @@ const TO = Ref(TimerOutput())
 
 const VERBOSE = Ref(false)
 const SHOW_ARGTYPES = Ref(false)
+const SHOW_DEF = Ref(false)
+const PREFIX = Ref(homedir() => "~")
 
 Cassette.@context TOCtx
 
@@ -18,10 +20,18 @@ function Cassette.overdub(ctx::TOCtx, f, args...)
         argtypes = typeof.(args)
         VERBOSE[] && println("OVERDUBBING: ", f, argtypes)
         # return @timeit TO "$f" f(args...)
-        timer_groupname = if SHOW_ARGTYPES[]
-            "$f $argtypes"
-        else
-            "$f"
+        timer_groupname = string(f)
+        if SHOW_ARGTYPES[]
+            timer_groupname *= string(argtypes)
+        end
+        if SHOW_DEF[]
+            filename, line = '?', '?'
+            try
+                filename, line = functionloc(f, argtypes)
+                filename = replace(filename, PREFIX[])
+            catch
+            end
+            timer_groupname *= " at " * filename * ':' * string(line)
         end
         return @timeit TO[] timer_groupname Cassette.recurse(ctx, f, args...)
     else

--- a/src/TimerOutputsTracked.jl
+++ b/src/TimerOutputsTracked.jl
@@ -40,10 +40,10 @@ function timetracked(f, args...; reset_timer=true, warn=false)
     return result
 end
 
-macro timetracked(ex)
+macro timetracked(ex, reset_timer=true, warn=false)
     @capture(ex, f_(args__))
     quote
-        TimerOutputsTracked.timetracked($f, $(args...))
+        TimerOutputsTracked.timetracked($f, $(args...); reset_timer=$reset_timer, warn=$warn)
     end |> esc
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,4 +50,8 @@ const tot = TimerOutputsTracked
         @test res == 7
         @test tot.hastimings()
     end
+    @testset "Arguments" begin
+        func(x, y) = x + y
+        @test @timetracked(func(1, 2)) == 3
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using TimerOutputsTracked
 using Test
 
-const tot = TimerOutputsTracked
+const TOT = TimerOutputsTracked
+const TEST_IO = (stdout, devnull)[1]  # select `devnull` if we have a lot of tests
 
 module MyModule
     export foo, bar
@@ -12,67 +13,67 @@ end
 
 @testset "Basics" begin
     @testset "Tracking (bookkeeping)" begin
-        @test isnothing(tot.tracked())
-        @test isnothing(tot.track(sin))
-        @test tot.istracked(sin)
-        @test isnothing(tot.untrack(sin))
-        @test !tot.istracked(sin)
-        @test isnothing(tot.track(sin, cos))
-        @test isnothing(tot.track([tan, exp]))
-        @test isnothing(tot.untrackall())
-        @test isempty(tot.gettracked())
+        @test isnothing(TOT.tracked(TEST_IO))
+        @test isnothing(TOT.track(sin))
+        @test TOT.istracked(sin)
+        @test isnothing(TOT.untrack(sin))
+        @test !TOT.istracked(sin)
+        @test isnothing(TOT.track(sin, cos))
+        @test isnothing(TOT.track([tan, exp]))
+        @test isnothing(TOT.untrackall())
+        @test isempty(TOT.gettracked())
     end
     @testset "Single argument" begin
-        tot.reset()
+        TOT.reset()
         @test timetracked(sin, 3) == sin(3)
-        @test !tot.hastimings()
-        @test isnothing(tot.track(sin))
+        @test !TOT.hastimings()
+        @test isnothing(TOT.track(sin))
         @test timetracked(sin, 3) == sin(3)
-        @test tot.hastimings()
-        @test isnothing(tot.timings_tracked())
-        @test isnothing(timings_tracked())  # exported
+        @test TOT.hastimings()
+        @test isnothing(TOT.timings_tracked(TEST_IO))
+        @test isnothing(timings_tracked(TEST_IO))  # exported
 
         # macro
-        tot.reset()
-        tot.track(sin)
-        @test !tot.hastimings()
+        TOT.reset()
+        TOT.track(sin)
+        @test !TOT.hastimings()
         res = @timetracked sin(3)
         @test res == sin(3)
-        @test tot.hastimings()
+        @test TOT.hastimings()
     end
     @testset "Multi-argument" begin
-        tot.reset()
+        TOT.reset()
         @test timetracked(+, 3, 4) == 7
-        @test !tot.hastimings()
-        @test isnothing(tot.track(+))
+        @test !TOT.hastimings()
+        @test isnothing(TOT.track(+))
         @test timetracked(+, 3, 4) == 7
-        @test tot.hastimings()
+        @test TOT.hastimings()
 
         # macro
-        tot.reset()
-        tot.track(+)
-        @test !tot.hastimings()
+        TOT.reset()
+        TOT.track(+)
+        @test !TOT.hastimings()
         @test @timetracked(+(3, 4)) == 7
-        @test tot.hastimings()
-        timings_tracked()
+        @test TOT.hastimings()
+        timings_tracked(TEST_IO)
     end
     @testset "Arguments" begin
         func(x, y) = x + y
         @test @timetracked(func(1, 2)) == 3
     end
     @testset "Track exported methods from Module" begin
-        tot.reset()
-        tot.track(MyModule)
-        @test tot.istracked(MyModule.foo)
-        @test tot.istracked(MyModule.bar)
+        TOT.reset()
+        TOT.track(MyModule)
+        @test TOT.istracked(MyModule.foo)
+        @test TOT.istracked(MyModule.bar)
     end
     @testset "Track all Module methods" begin
-        tot.reset()
-        tot.track(MyModule; all = true)
-        @test tot.istracked(MyModule.foo)
-        @test tot.istracked(MyModule.bar)
-        @test tot.istracked(MyModule.baz)  # track unexported method
+        TOT.reset()
+        TOT.track(MyModule; all = true)
+        @test TOT.istracked(MyModule.foo)
+        @test TOT.istracked(MyModule.bar)
+        @test TOT.istracked(MyModule.baz)  # track unexported method
         @test @timetracked(MyModule.baz()) == 6
-        timings_tracked()
+        timings_tracked(TEST_IO)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,13 @@ using Test
 
 const tot = TimerOutputsTracked
 
+module MyModule
+    export foo, bar
+    foo() = 1
+    bar() = 2
+    baz() = 3  # unexported
+end
+
 @testset "Basics" begin
     @testset "Tracking (bookkeeping)" begin
         @test isnothing(tot.tracked())
@@ -25,7 +32,7 @@ const tot = TimerOutputsTracked
         @test isnothing(tot.timings_tracked())
         @test isnothing(timings_tracked()) # exported
 
-        #macro
+        # macro
         tot.reset()
         tot.track(sin)
         @test !tot.hastimings()
@@ -42,7 +49,7 @@ const tot = TimerOutputsTracked
         @test tot.hastimings()
         @test isnothing(tot.timings_tracked())
 
-        #macro
+        # macro
         tot.reset()
         tot.track(+)
         @test !tot.hastimings()
@@ -53,5 +60,16 @@ const tot = TimerOutputsTracked
     @testset "Arguments" begin
         func(x, y) = x + y
         @test @timetracked(func(1, 2)) == 3
+    end
+    @testset "Track exported methods from Module" begin
+        tot.reset()
+        tot.track(MyModule)
+        @test tot.istracked(MyModule.foo)
+        @test tot.istracked(MyModule.bar)
+    end
+    @testset "Track all Module methods" begin
+        tot.reset()
+        tot.track(MyModule; all = true)
+        @test tot.istracked(MyModule.baz)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ module MyModule
     baz() = 3 + bar()  # unexported
 end
 
+mysum(x, y) = x + y
+
 @testset "Basics" begin
     @testset "Tracking (bookkeeping)" begin
         @test isnothing(TOT.tracked(TEST_IO))
@@ -57,9 +59,10 @@ end
         @test TOT.hastimings()
         timings_tracked(TEST_IO)
     end
-    @testset "Arguments" begin
-        func(x, y) = x + y
-        @test @timetracked(func(1, 2)) == 3
+    @testset "Positional arguments" begin
+        TOT.reset()
+        TOT.track(mysum)
+        @test @timetracked(mysum(1, 2)) == 3
     end
     @testset "Track exported methods from Module" begin
         TOT.reset()
@@ -74,6 +77,12 @@ end
         @test TOT.istracked(MyModule.bar)
         @test TOT.istracked(MyModule.baz)  # track unexported method
         @test @timetracked(MyModule.baz()) == 6
+        timings_tracked(TEST_IO)
+    end
+    @testset "Options" begin
+        TOT.reset()
+        TOT.track(mysum)
+        @test @timetracked(mysum(2, 3.0), functionloc=true, argtypes=true) == 5.0
         timings_tracked(TEST_IO)
     end
 end


### PR DESCRIPTION
@carstenbauer, thanks for this attempt, I'm also interested in an automated allocations reporting tool.

- allow tracking all functions (even unexported ones) from a module;
- attempt to print method source file and line number (an optionally remove a prefix from filename);
- add basic `ci` configuration;
- add more tests, and rework test output;
- fix `@timetracked` macro (current master fails the following):

```julia
julia> using UnicodePlots, TimerOutputsTracked
julia> @timetracked lineplot(1:2)
ERROR: MethodError: no method matching lineplot(::Expr)
```

By the way, should the repo be renamed to `TimerOutputsTracked.jl` ?

Example usage (it is now trivial to focus on reducing allocations, and the process in non-intrusive):
```julia
julia> using UnicodePlots, TimerOutputsTracked
julia> TimerOutputsTracked.reset();
julia> TimerOutputsTracked.track(UnicodePlots; all = true);  # track all `UnicodePlots` methods (even unexported ones)
julia> @timetracked lineplot(1:2) functionloc=true;
julia> timings_tracked();
```
<details>

```julia
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                        Time                    Allocations      
                                                                                                               ───────────────────────   ────────────────────────
                                               Tot / % measured:                                                    1.30s /  23.6%           6.23MiB /  99.4%    

 Section                                                                                               ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 lineplot at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:78                                      1    307ms  100.0%   307ms   6.20MiB  100.0%  6.20MiB
   #lineplot#150 at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:78                               1    307ms  100.0%   307ms   6.19MiB   99.9%  6.19MiB
     lineplot at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:67                                  1    306ms   99.9%   306ms   6.19MiB   99.8%  6.19MiB
       lineplot at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:67                                1    306ms   99.9%   306ms   6.18MiB   99.8%  6.18MiB
         #lineplot#149 at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:67                         1    306ms   99.9%   306ms   6.17MiB   99.7%  6.17MiB
           lineplot! at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:80                           1    306ms   99.7%   306ms   6.14MiB   99.2%  6.14MiB
             #lineplot!#151 at ~/.julia/dev/UnicodePlots.jl/src/interface/lineplot.jl:80                    1    306ms   99.7%   306ms   6.14MiB   99.1%  6.14MiB
               lines! at ~/.julia/dev/UnicodePlots.jl/src/plot.jl:510                                       1    305ms   99.6%   305ms   6.13MiB   98.9%  6.13MiB
                 #lines!#88 at ~/.julia/dev/UnicodePlots.jl/src/plot.jl:510                                 1    305ms   99.6%   305ms   6.12MiB   98.8%  6.12MiB
                   lines! at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:180                                 1    305ms   99.5%   305ms   6.11MiB   98.6%  6.11MiB
                     lines! at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:114                               1    305ms   99.5%   305ms   6.10MiB   98.5%  6.10MiB
                       lines! at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:114                             1    305ms   99.4%   305ms   6.10MiB   98.4%  6.10MiB
                         pixel! at ~/.julia/dev/UnicodePlots.jl/src/canvas/braillecanvas.jl:76             81    296ms   96.6%  3.66ms   5.49MiB   88.6%  69.4KiB
                           pixel_to_char_point_off at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:304       81    259ms   84.5%  3.20ms   1.46MiB   23.5%  18.4KiB
                             x_pixel_per_char at ?:?                                                      162    494μs    0.2%  3.05μs     0.00B    0.0%    0.00B
                             y_pixel_per_char at ?:?                                                      162    409μs    0.1%  2.52μs     0.00B    0.0%    0.00B
                             pixel_width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:12                  81   47.8μs    0.0%   590ns   6.33KiB    0.1%    80.0B
                             pixel_height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:11                 81   40.8μs    0.0%   504ns   6.33KiB    0.1%    80.0B
                           ansi_color at ~/.julia/dev/UnicodePlots.jl/src/common.jl:537                    81   10.3ms    3.3%   127μs   1.05MiB   16.9%  13.3KiB
                             ansi_color at ~/.julia/dev/UnicodePlots.jl/src/common.jl:542                  81   4.61ms    1.5%  56.9μs    375KiB    5.9%  4.63KiB
                               ansi_4bit_to_8bit at ~/.julia/dev/UnicodePlots.jl/src/common.jl:521         81   1.37ms    0.4%  16.9μs   16.5KiB    0.3%     208B
                             ignored_color at ~/.julia/dev/UnicodePlots.jl/src/common.jl:515               81    172μs    0.1%  2.12μs   7.59KiB    0.1%    96.0B
                           set_color! at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:54                     81   4.51ms    1.5%  55.7μs    545KiB    8.6%  6.72KiB
                             set_color! at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:54                   81   1.52ms    0.5%  18.7μs    157KiB    2.5%  1.94KiB
                               blend_colors at ~/.julia/dev/UnicodePlots.jl/src/common.jl:497              32    123μs    0.0%  3.84μs   6.00KiB    0.1%     192B
                           valid_x_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:38                  81   2.71ms    0.9%  33.4μs    348KiB    5.5%  4.30KiB
                             pixel_width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:12                  81   74.1μs    0.0%   915ns   6.33KiB    0.1%    80.0B
                           valid_y_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:37                  81   2.42ms    0.8%  29.9μs    348KiB    5.5%  4.30KiB
                             pixel_height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:11                 81   52.0μs    0.0%   642ns   6.33KiB    0.1%    80.0B
                         scale_y_to_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:31                  2    550μs    0.2%   275μs   36.9KiB    0.6%  18.5KiB
                           y_to_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:18                      2    431μs    0.1%   215μs   27.7KiB    0.4%  13.9KiB
                             pixel_height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:11                  2   5.46μs    0.0%  2.73μs      160B    0.0%    80.0B
                             origin_y at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:13                      2   5.35μs    0.0%  2.67μs      192B    0.0%    96.0B
                             height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:15                        2   3.76μs    0.0%  1.88μs      192B    0.0%    96.0B
                         scale_x_to_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:32                  2    498μs    0.2%   249μs   36.9KiB    0.6%  18.4KiB
                           x_to_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:24                      2    372μs    0.1%   186μs   27.6KiB    0.4%  13.8KiB
                             pixel_width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:12                   2   4.67μs    0.0%  2.33μs      160B    0.0%    80.0B
                             origin_x at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:14                      2   4.43μs    0.0%  2.21μs      192B    0.0%    96.0B
                             width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:16                         2   3.65μs    0.0%  1.82μs      192B    0.0%    96.0B
                         y_to_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:18                        2    370μs    0.1%   185μs   27.8KiB    0.4%  13.9KiB
                           pixel_height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:11                    2   4.62μs    0.0%  2.31μs      160B    0.0%    80.0B
                           height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:15                          2   3.80μs    0.0%  1.90μs      192B    0.0%    96.0B
                           origin_y at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:13                        2   2.31μs    0.0%  1.15μs      192B    0.0%    96.0B
                         x_to_pixel at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:24                        2    350μs    0.1%   175μs   27.7KiB    0.4%  13.9KiB
                           pixel_width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:12                     2   4.07μs    0.0%  2.04μs      160B    0.0%    80.0B
                           width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:16                           2   3.79μs    0.0%  1.90μs      192B    0.0%    96.0B
                           origin_x at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:14                        2   2.56μs    0.0%  1.28μs      192B    0.0%    96.0B
                         valid_y at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:34                           1    212μs    0.1%   212μs   14.1KiB    0.2%  14.1KiB
                           origin_y at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:13                        2   6.84μs    0.0%  3.42μs      192B    0.0%    96.0B
                           height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:15                          1   3.51μs    0.0%  3.51μs     96.0B    0.0%    96.0B
                         valid_x at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:35                           1    197μs    0.1%   197μs   14.1KiB    0.2%  14.1KiB
                           origin_x at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:14                        2   5.75μs    0.0%  2.88μs      192B    0.0%    96.0B
                           width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:16                           1   4.08μs    0.0%  4.08μs     96.0B    0.0%    96.0B
                         origin_y at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:13                          2   5.57μs    0.0%  2.78μs      192B    0.0%    96.0B
                         origin_x at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:14                          2   4.25μs    0.0%  2.13μs      192B    0.0%    96.0B
                         height at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:15                            1   1.03μs    0.0%  1.03μs     96.0B    0.0%    96.0B
                         width at ~/.julia/dev/UnicodePlots.jl/src/canvas.jl:16                             1    868ns    0.0%   868ns     96.0B    0.0%    96.0B
                   transform at ~/.julia/dev/UnicodePlots.jl/src/plot.jl:506                                1   10.7μs    0.0%  10.7μs      240B    0.0%     240B
               next_color! at ~/.julia/dev/UnicodePlots.jl/src/plot.jl:292                                  1   46.6μs    0.0%  46.6μs      560B    0.0%     560B
           split_plot_kw at ~/.julia/dev/UnicodePlots.jl/src/common.jl:624                                  1   92.4μs    0.0%  92.4μs   4.94KiB    0.1%  4.94KiB
             #split_plot_kw#22 at ~/.julia/dev/UnicodePlots.jl/src/common.jl:624                            1   7.95μs    0.0%  7.95μs     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

</details>

EDIT: awesome, I've already cut down allocations on the example by `~20%`.

Regarding keyword arguments, we seem to hit https://github.com/JuliaLabs/Cassette.jl/issues/48 - https://github.com/JuliaLabs/Cassette.jl/issues/152 :cry:.
Can anyone advise what to do here ?